### PR TITLE
Change delaySecond to delayMilliseconds

### DIFF
--- a/src/EvilAppleJuice-ESP32-INO/EvilAppleJuice-ESP32-INO.ino
+++ b/src/EvilAppleJuice-ESP32-INO/EvilAppleJuice-ESP32-INO.ino
@@ -7,7 +7,7 @@
 #include <BLEServer.h>
 
 BLEAdvertising *pAdvertising;  // global variable
-uint32_t delaySeconds = 1;
+uint32_t delayMilliseconds = 1000;
 
 const uint8_t DEVICES[][31] = {
   {0x1e, 0xff, 0x4c, 0x00, 0x07, 0x19, 0x07, 0x02, 0x20, 0x75, 0xaa, 0x30, 0x01, 0x00, 0x00, 0x45, 0x12, 0x12, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
@@ -130,6 +130,6 @@ void loop() {
   // Start advertising
   Serial.println("Sending Advertisement...");
   pAdvertising->start();
-  delay(delaySeconds * 1000); // delay for delaySeconds seconds
+  delay(delayMilliseconds); // delay for delayMilliseconds ms
   pAdvertising->stop();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@
 #include "devices.hpp"
 
 BLEAdvertising *pAdvertising;  // global variable
-uint32_t delaySeconds = 1;
+uint32_t delayMilliseconds = 1000;
 
 void setup() {
   Serial.begin(115200);
@@ -109,6 +109,6 @@ void loop() {
   // Turn lights off while "sleeping"
   digitalWrite(12, LOW);
   digitalWrite(13, LOW);
-  delay(delaySeconds * 1000); // delay for delaySeconds seconds
+  delay(delayMilliseconds); // delay for delayMilliseconds ms
   pAdvertising->stop();
 }


### PR DESCRIPTION
Makes it easier to reduce the value, since:

* `uint32_t` cannot be between 0 & 1 (e.g. for half a second)
* If we change the `* 1000` multiplier, the name `delaySeconds` is misleading.

Just store milliseconds directly.