### PR TITLE
Set Default env to AirM2M

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,6 +8,9 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+[platformio]
+default_envs = airm2m_core_esp32c3
+
 [env:airm2m_core_esp32c3]
 platform = espressif32
 board = airm2m_core_esp32c3


### PR DESCRIPTION
Users can override it in PlatformIO if they want:

![image](https://github.com/ckcr4lyf/EvilAppleJuice-ESP32/assets/6680615/a9421706-8c99-4d77-93c2-78900977ff10)
