### PR TITLE
Add random transmit power and increase the maximum power

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,8 +7,6 @@
 #include <BLEUtils.h>
 #include <BLEServer.h>
 
-#include <esp_gap_ble_api.h>
-
 #include "devices.hpp"
 
 BLEAdvertising *pAdvertising;  // global variable

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,8 @@
 #include <BLEUtils.h>
 #include <BLEServer.h>
 
+#include <esp_gap_ble_api.h>
+
 #include "devices.hpp"
 
 BLEAdvertising *pAdvertising;  // global variable
@@ -23,8 +25,9 @@ void setup() {
 
   BLEDevice::init("AirPods 69");
 
-  // Increase the BLE Power to 9dBm (MAX)
-  esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, ESP_PWR_LVL_P9);
+  // Increase the BLE Power to 21dBm (MAX)
+  // https://docs.espressif.com/projects/esp-idf/en/stable/esp32c3/api-reference/bluetooth/controller_vhci.html
+  esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, ESP_PWR_LVL_P21);
 
   // Create the BLE Server
   BLEServer *pServer = BLEDevice::createServer();
@@ -114,4 +117,22 @@ void loop() {
   digitalWrite(13, LOW);
   delay(delayMilliseconds); // delay for delayMilliseconds ms
   pAdvertising->stop();
+
+  // Random signal strength increases the difficulty of tracking the signal
+  int rand_val = random(100);  // Generate a random number between 0 and 99
+  if (rand_val < 70) {  // 70% probability
+      esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, ESP_PWR_LVL_P21);
+  } else if (rand_val < 80) {  // 10% probability
+      esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, ESP_PWR_LVL_P18);
+  } else if (rand_val < 90) {  // 10% probability
+      esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, ESP_PWR_LVL_P15);
+  } else if (rand_val < 95) {  // 5% probability
+      esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, ESP_PWR_LVL_P12);
+  } else if (rand_val < 98) {  // 3% probability
+      esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, ESP_PWR_LVL_P9);
+  } else if (rand_val < 99) {  // 1% probability
+      esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, ESP_PWR_LVL_P6);
+  } else {  // 1% probability
+      esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, ESP_PWR_LVL_N0);
+  }
 }


### PR DESCRIPTION
Add random signal transmission power to increase tracking difficulty. Increase transmit power to +21dbm.

https://docs.espressif.com/projects/esp-idf/en/stable/esp32c3/api-reference/bluetooth/controller_vhci.html#_CPPv4N17esp_power_level_t15ESP_PWR_LVL_P21E 

enumerator ESP_PWR_LVL_P21

Corresponding to +21dbm