### PR TITLE
Add support for ESP32 Dev Module

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,12 @@
 [platformio]
 default_envs = airm2m_core_esp32c3
 
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+
 [env:airm2m_core_esp32c3]
 platform = espressif32
 board = airm2m_core_esp32c3
@@ -35,7 +41,6 @@ platform = espressif32
 board = nodemcu-32s
 framework = arduino
 monitor_speed = 115200
-
 
 [env:m5stickc]
 platform = espressif32


### PR DESCRIPTION
Corresponding hardware: <https://www.espressif.com/en/products/devkits?id=ESP32>

PlatformIO documentation: <https://docs.platformio.org/en/latest/boards/espressif32/esp32dev.html>

```ini
[env:esp32dev]
platform = espressif32
board = esp32dev
framework = arduino
monitor_speed = 115200
```
