### PR TITLE
Add GitHub Actions CI to build firmware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,78 @@
+name: Build, Upload and Release Firmware
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  get_envs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+      - name: Get default environments
+        id: envs
+        run: |
+          echo "environments=$(pio project config --json-output | jq -cr '[.[][0] | select(contains("env")) | split(":")[1]]')" >> $GITHUB_OUTPUT
+    outputs:
+      environments: ${{ steps.envs.outputs.environments }}
+
+  build:
+    needs: get_envs
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: ${{ fromJSON(needs.get_envs.outputs.environments) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build PlatformIO Project
+        run: pio run -e ${{ matrix.environment }}
+
+      - name: Locate and rename firmware binary
+        id: firmware
+        run: |
+          DATE=$(date +'%Y%m%d')
+          PROJECT_NAME=${GITHUB_REPOSITORY##*/}
+          FIRMWARE_PATH=$(find .pio -name 'firmware.bin')
+          FILENAME="${PROJECT_NAME}-${{ matrix.environment }}-${DATE}.bin"
+          mv "$FIRMWARE_PATH" "$FILENAME"
+          echo "DATE=$DATE" >> $GITHUB_ENV
+          echo "PROJECT_NAME=$PROJECT_NAME" >> $GITHUB_ENV
+          echo "FILENAME=$FILENAME" >> $GITHUB_ENV
+          echo "::set-output name=DATE::$DATE"  # Set output
+        shell: bash
+
+      - name: Upload firmware binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-${{ matrix.environment }}
+          path: ${{ env.FILENAME }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download firmware binary
+        uses: actions/download-artifact@v4
+        with:
+          path: build
+          pattern: firmware-*
+          merge-multiple: true
+
+      - name: Publish release
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          automatic_release_tag: latest
+          prerelease: false
+          files: build/*.bin

--- a/README.md
+++ b/README.md
@@ -46,10 +46,39 @@ And it makes these random choices every time it runs (default re-advertise every
 
 Given the 29 devices and the 3 advertisement types, there are a total of 87 unique possible advertisements (ignoring the random source MAC) possible, of which one is broadcast every second.
 
-## Usage
+## Compatibility
 
-Clone the repo, and easiest would be to use VS Code w/ PlatformIO to upload it to your ESP32.
+This project has been tested on:
 
-This project has been tested on an [ESP32-C3 from AirM2M](https://wiki.luatos.com/chips/esp32c3/board.html).
++ [ESP32-C3 from AirM2M](https://wiki.luatos.com/chips/esp32c3/board.html).
++ [M5Stick-C](https://shop.m5stack.com/products/stick-c)
 
+## How to use
 
+This project offers an easy way to update your ESP32 device with the latest firmware, catering to both technical and less technical users. Here's how you can get started:
+
+### Quick Start with Pre-compiled Firmware
+
+1. **Download the Firmware**: Go to the [Releases](https://github.com/ckcr4lyf/EvilAppleJuice-ESP32/releases/tag/latest) section of this GitHub repository and download the latest `.bin` file.
+2. **Connect Your Device**: Make sure your ESP32 device is connected to your computer via USB.
+3. **Flash the Firmware**:
+    - **Using webesp**: Navigate to the online esptool (eg: <https://lsong.org/webesp>), select your `.bin` file, and follow the instructions to flash your device directly from your browser.
+    - **Using esptool**: Open a command line or terminal. Execute the following command, replacing `<YourSerialPort>` with your device's serial port and `<FirmwareFile.bin>` with the path to your downloaded `.bin` file:
+      ```shell
+      esptool.py --port /dev/cu.usbserial-xxx write_flash 0x10000 ~/Downloads/EvilAppleJuice-ESP32-esp32dev-20240328.bin
+      ```
+
+This method is straightforward and does not require in-depth programming knowledge, making it accessible for everyone.
+
+### Build from Source
+
+If you prefer to compile the firmware yourself or wish to contribute to the project, here's how you can set up your environment:
+
+1. **Clone the Repository**: Use your preferred method to clone this repository to your local machine.
+2. **Setup Your Development Environment**: Download and install Visual Studio Code (VS Code) and the PlatformIO extension. This setup is recommended for compiling and uploading the firmware to your ESP32 device.
+3. **Open the Project in VS Code**: Navigate to the cloned project folder and open it in VS Code. PlatformIO will automatically handle the project configuration.
+4. **Upload the Firmware**: With your ESP32 device connected to your computer, use the PlatformIO interface in VS Code to compile and upload the firmware.
+
+Happy hacking :>
+
+---


### PR DESCRIPTION
I have add a GitHub Actions workflow to automatically build the firmware binary and publish it to the latest release.

It looks like: https://github.com/song940/EvilAppleJuice-ESP32/releases/tag/latest

By integrating Continuous Integration (CI), we ensure that the code repository's builds are always available and free from significant build issues.

Moreover, ordinary users can now more easily flash the firmware through [esptool.py](https://github.com/espressif/esptool) or [webesp](https://lsong.org/webesp) via a browser, making the process more user-friendly and accessible to non-experts.